### PR TITLE
Functions become plain object when they're moved

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,11 +11,21 @@ function toObject(val) {
 	return Object(val);
 }
 
-function isFunc(val) {
-	return typeof val === 'function';
+function assignKey(to, from, key) {
+	var val = from[key];
+
+	if (typeof val === 'undefined' || val === null) {
+		return;
+	}
+
+	if (typeof to[key] === 'undefined' || !isObj(val)) {
+		to[key] = val;
+	} else {
+		to[key] = assign(Object(to[key]), from[key]);
+	}
 }
 
-function base(to, from) {
+function assign(to, from) {
 	if (to === from) {
 		return to;
 	}
@@ -24,15 +34,7 @@ function base(to, from) {
 
 	for (var key in from) {
 		if (hasOwnProperty.call(from, key)) {
-			var val = from[key];
-
-			if (Array.isArray(val)) {
-				to[key] = val.slice();
-			} else if (isObj(val) && !isFunc(val)) {
-				to[key] = base(to[key] || {}, val);
-			} else if (val !== undefined) {
-				to[key] = val;
-			}
+			assignKey(to, from, key);
 		}
 	}
 
@@ -41,7 +43,7 @@ function base(to, from) {
 
 		for (var i = 0; i < symbols.length; i++) {
 			if (propIsEnumerable.call(from, symbols[i])) {
-				to[symbols[i]] = from[symbols[i]];
+				assignKey(to, from, symbols[i]);
 			}
 		}
 	}
@@ -53,7 +55,7 @@ module.exports = function deepAssign(target) {
 	target = toObject(target);
 
 	for (var s = 1; s < arguments.length; s++) {
-		base(target, arguments[s]);
+		assign(target, arguments[s]);
 	}
 
 	return target;

--- a/index.js
+++ b/index.js
@@ -18,7 +18,13 @@ function assignKey(to, from, key) {
 		return;
 	}
 
-	if (to[key] === undefined || !isObj(val)) {
+	if (Object.hasOwnProperty.call(to, key)) {
+		if (to[key] === undefined || to[key] === null) {
+			throw new TypeError('Cannot convert undefined or null to object (' + key + ')');
+		}
+	}
+
+	if (!Object.hasOwnProperty.call(to, key) || !isObj(val)) {
 		to[key] = val;
 	} else {
 		to[key] = assign(Object(to[key]), from[key]);

--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ function toObject(val) {
 	return Object(val);
 }
 
+function isFunc(val) {
+	return typeof val === 'function';
+}
+
 function base(to, from) {
 	if (to === from) {
 		return to;
@@ -24,7 +28,7 @@ function base(to, from) {
 
 			if (Array.isArray(val)) {
 				to[key] = val.slice();
-			} else if (isObj(val)) {
+			} else if (isObj(val) && !isFunc(val)) {
 				to[key] = base(to[key] || {}, val);
 			} else if (val !== undefined) {
 				to[key] = val;

--- a/index.js
+++ b/index.js
@@ -14,11 +14,11 @@ function toObject(val) {
 function assignKey(to, from, key) {
 	var val = from[key];
 
-	if (typeof val === 'undefined' || val === null) {
+	if (val === undefined || val === null) {
 		return;
 	}
 
-	if (typeof to[key] === 'undefined' || !isObj(val)) {
+	if (to[key] === undefined || !isObj(val)) {
 		to[key] = val;
 	} else {
 		to[key] = assign(Object(to[key]), from[key]);

--- a/index.js
+++ b/index.js
@@ -18,13 +18,13 @@ function assignKey(to, from, key) {
 		return;
 	}
 
-	if (Object.hasOwnProperty.call(to, key)) {
+	if (hasOwnProperty.call(to, key)) {
 		if (to[key] === undefined || to[key] === null) {
 			throw new TypeError('Cannot convert undefined or null to object (' + key + ')');
 		}
 	}
 
-	if (!Object.hasOwnProperty.call(to, key) || !isObj(val)) {
+	if (!hasOwnProperty.call(to, key) || !isObj(val)) {
 		to[key] = val;
 	} else {
 		to[key] = assign(Object(to[key]), from[key]);

--- a/test.js
+++ b/test.js
@@ -8,6 +8,76 @@ test('assign own enumerable propreties from source to target object', t => {
 	t.end();
 });
 
+test('do not assign null values', t => {
+	t.same(fn({}, {foo: null}), {});
+	t.end();
+});
+
+test('assign values to null targets', t => {
+	t.same(fn({foo: null}, {foo: {}}), {foo: {}});
+	t.end();
+});
+
+test('do not assign undefined values', t => {
+	t.same(fn({}, {foo: undefined}), {});
+	t.end();
+});
+
+test('assign values to undefined targets', t => {
+	t.same(fn({foo: undefined}, {foo: {}}), {foo: {}});
+	t.end();
+});
+
+test('support numbers as targets', t => {
+	var target = fn({answer: 42}, {answer: {rainbows: 'many'}});
+	t.is(target.answer / 7, 6);
+	t.is(target.answer.constructor, Number);
+	t.is(target.answer.rainbows, 'many');
+	t.end();
+});
+
+test('support boolean as targets', t => {
+	var target = fn({foo: true}, {foo: {rainbows: 'many'}});
+	t.is(target.foo.toString(), 'true');
+	t.is(target.foo.constructor, Boolean);
+	t.is(target.foo.rainbows, 'many');
+	t.end();
+});
+
+test('support strings as targets', t => {
+	var target = fn({rainbows: 'many'}, {rainbows: {answer: 42}});
+	t.is('' + target.rainbows, 'many');
+	t.is(target.rainbows.constructor, String);
+	t.is(target.rainbows.answer, 42);
+	t.end();
+});
+
+test('support arrays as targets', t => {
+	var target = {a: ['many']};
+	var source = {a: []};
+	source.a[2] = 'unicorns';
+	fn(target, source, {a: {answer: 42}});
+	t.is(target.a[0], 'many');
+	t.is(target.a[1], undefined);
+	t.is(target.a[2], 'unicorns');
+	t.is(target.a.constructor, Array);
+	t.is(target.a.answer, 42);
+	t.end();
+});
+
+test('support functions', t => {
+	var oracle42 = () => 42;
+	var oracle666 = () => 666;
+	oracle42.foo = true;
+	oracle42.bar = true;
+	oracle666.bar = false;
+	var target = fn({}, {oracle: oracle42}, {oracle: oracle666});
+	t.is(target.oracle(), 42);
+	t.is(target.oracle.foo, true);
+	t.is(target.oracle.bar, false);
+	t.end();
+});
+
 test('support multiple sources', t => {
 	t.same(fn({foo: 0}, {bar: 1}, {bar: 2}), {foo: 0, bar: 2});
 	t.same(fn({}, {}, {foo: 1}), {foo: 1});
@@ -90,6 +160,13 @@ if (typeof Symbol !== 'undefined') {
 		source[sym] = 'bar';
 		fn(target, source);
 		t.is(target[sym], 'bar');
+		t.end();
+	});
+
+	test('support symbols as targets', t => {
+		var target = fn({sym: Symbol('foo')}, {sym: {rainbows: 'many'}});
+		t.is(target.sym.constructor, Symbol);
+		t.is(target.sym.rainbows, 'many');
 		t.end();
 	});
 

--- a/test.js
+++ b/test.js
@@ -134,6 +134,13 @@ test('support `Object.create(null)` objects', t => {
 	t.end();
 });
 
+test('support `Object.create(null)` targets', t => {
+	var obj = Object.create(null);
+	obj.foo = true;
+	t.same(fn(obj, {bar: false}), {foo: true, bar: false});
+	t.end();
+});
+
 test('preserve property order', t => {
 	var letters = 'abcdefghijklmnopqrst';
 	var source = {};

--- a/test.js
+++ b/test.js
@@ -13,8 +13,16 @@ test('do not assign null values', t => {
 	t.end();
 });
 
-test('assign values to null targets', t => {
-	t.same(fn({foo: null}, {foo: {}}), {foo: {}});
+test('throw TypeError on null targets', t => {
+	t.throws(() => fn({foo: null}, {foo: {}}), TypeError);
+	t.end();
+});
+
+test('assign proprety, if proprety is null in the prototype chain', t => {
+	var Unicorn = () => {};
+	Unicorn.prototype.rainbows = null;
+	var unicorn = new Unicorn();
+	t.is(fn(unicorn, {rainbows: 'many'}).rainbows, 'many');
 	t.end();
 });
 
@@ -23,8 +31,27 @@ test('do not assign undefined values', t => {
 	t.end();
 });
 
-test('assign values to undefined targets', t => {
-	t.same(fn({foo: undefined}, {foo: {}}), {foo: {}});
+test('throw TypeError on undefined targets', t => {
+	t.throws(() => fn({foo: undefined}, {foo: {}}), TypeError);
+	t.end();
+});
+
+test('assign proprety, if proprety is undefined in the prototype chain', t => {
+	var Unicorn = () => {};
+	Unicorn.prototype.rainbows = undefined;
+	var unicorn = new Unicorn();
+	t.is(fn(unicorn, {rainbows: 'many'}).rainbows, 'many');
+	t.end();
+});
+
+test('do not merge with a target proprety in the prototype chain', t => {
+	var amountOfRainbows = {amount: 'many'};
+	var Unicorn = () => {};
+	Unicorn.prototype.rainbows = amountOfRainbows;
+	var unicorn = fn(new Unicorn(), {rainbows: 'none'});
+	t.is(unicorn.rainbows, 'none');
+	t.is(unicorn.rainbows.amount, undefined);
+	t.is(Unicorn.prototype.rainbows, amountOfRainbows);
 	t.end();
 });
 

--- a/test.js
+++ b/test.js
@@ -106,3 +106,12 @@ if (typeof Symbol !== 'undefined') {
 		t.end();
 	});
 }
+
+test('do not transform functions', t => {
+	var target = {
+		foo: function bar() {}
+	};
+	var source = {};
+	t.is(typeof fn({}, target, source).foo, 'function');
+	t.end();
+});


### PR DESCRIPTION
When I'd like to clone an object to a brand new one and there's a function in the source objects, the function becomes a plain object in the final result.

it works fine:

``` js
var a = {
  foo: function bar() {}
};
var result = deepAssign(a, {});
console.log(typeof result.foo); // --> 'function'
```

but in this case the function becomes a plain object:

``` js
var a = {
  foo: function bar() {}
};
var result = deepAssign({}, a, {});
console.log(typeof result.foo); // --> 'object' :((
```
