### PR TITLE
Fix message in TypeError for null/undefined target

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var propIsEnumerable = Object.prototype.propertyIsEnumerable;
 
 function toObject(val) {
 	if (val === null || val === undefined) {
-		throw new TypeError('Sources cannot be null or undefined');
+		throw new TypeError('Cannot convert undefined or null to object');
 	}
 
 	return Object(val);


### PR DESCRIPTION
The text of the TypeError thrown by isObject mentioned "Sources", however the method is only used to check the target (in fact the message was a lie, as null / undefined sources work just fine).
